### PR TITLE
Add upx stage to save more file space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ matrix:
     - go: 1.x
       env: RELEASE=true
     - go: master
+      addons:
+          apt:
+            packages:
+            - upx-ucl
   allow_failures:
     - go: master
 
 after_success:
   - go build -ldflags="-s -w"
-
+  - upx --best --lzma docker-systemd-shim
 deploy:
   provider: releases
   skip_cleanup: true


### PR DESCRIPTION
Addresses: https://github.com/mback2k/docker-systemd-shim/issues/1

There are certainly trade-offs here:

- the startup time increases
- if you run several instances of an app, they consume more memory because code uses anon mapping instead of file mapping
- the whole executable file is loaded to memory at startup

However most of these have minimal impact with such a trivial cli app and this method reaches the target @ right around 2Mb